### PR TITLE
chore: pin GitHub Actions to immutable SHAs + pinning lint

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,16 +14,16 @@ jobs:
       IMAGE_NAME: mikefarah/yq
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           version: latest
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '^1.20'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/pinning-lint.yml
+++ b/.github/workflows/pinning-lint.yml
@@ -1,0 +1,31 @@
+name: Pinning lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+
+permissions: {}
+
+jobs:
+  pinning-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run pinning-lint
+        uses: RayaTheApp/actions/.github/actions/pinning-lint@master
+        with:
+          mode: blocking

--- a/.github/workflows/pinning-lint.yml
+++ b/.github/workflows/pinning-lint.yml
@@ -25,7 +25,120 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - name: Run pinning-lint
-        uses: RayaTheApp/actions/.github/actions/pinning-lint@master
-        with:
-          mode: blocking
+
+      # Inline zizmor audit: public forks cannot consume composite actions from
+      # the private RayaTheApp/actions repo. Logic mirrors pinning-lint@master.
+      - name: Install zizmor
+        shell: bash
+        env:
+          # Bump these together when upgrading zizmor. Checksums come from
+          # `sha256sum` of the github.com/zizmorcore/zizmor release tarballs.
+          ZIZMOR_VERSION: "1.24.1"
+          ZIZMOR_SHA256_X86_64: "a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03"
+          ZIZMOR_SHA256_AARCH64: "d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d"
+        run: |
+          set -euo pipefail
+
+          ARCH="$(uname -m)"
+          case "$ARCH" in
+            x86_64)  TARGET="x86_64-unknown-linux-gnu";  EXPECTED_SHA="$ZIZMOR_SHA256_X86_64" ;;
+            aarch64) TARGET="aarch64-unknown-linux-gnu"; EXPECTED_SHA="$ZIZMOR_SHA256_AARCH64" ;;
+            *) echo "::error::pinning-lint: unsupported runner arch '$ARCH' (expected x86_64 or aarch64)"; exit 1 ;;
+          esac
+
+          URL="https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-${TARGET}.tar.gz"
+          TMP="$(mktemp -d)"
+          trap 'rm -rf "$TMP"' EXIT
+          cd "$TMP"
+
+          curl -fsSL "$URL" -o zizmor.tar.gz
+          echo "${EXPECTED_SHA}  zizmor.tar.gz" | sha256sum -c -
+          tar xzf zizmor.tar.gz
+
+          mkdir -p "${HOME}/.local/bin"
+          install -m 755 zizmor "${HOME}/.local/bin/zizmor"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+
+          "${HOME}/.local/bin/zizmor" --version
+
+      - name: Run pinning audit
+        id: audit
+        shell: bash
+        env:
+          MODE: blocking
+          CONFIG_PATH: zizmor.yml
+        run: |
+          set -uo pipefail
+
+          case "$MODE" in
+            advisory|blocking) ;;
+            *) echo "::error::pinning-lint: invalid mode '$MODE' (expected 'advisory' or 'blocking')"; exit 1 ;;
+          esac
+
+          OUTPUT="$(mktemp)"
+          trap 'rm -f "$OUTPUT"' EXIT
+
+          zizmor \
+            --persona=regular \
+            --no-online-audits \
+            --format=json \
+            --config="$CONFIG_PATH" \
+            . > "$OUTPUT" || true
+
+          if ! jq -e 'type == "array"' "$OUTPUT" > /dev/null 2>&1; then
+            echo "::error::pinning-lint: zizmor did not produce valid JSON output. Run logs above."
+            cat "$OUTPUT" >&2 || true
+            exit 1
+          fi
+
+          FINDINGS_COUNT="$(jq '[.[] | select(.ident == "unpinned-uses")] | length' "$OUTPUT")"
+
+          if [[ "$FINDINGS_COUNT" -eq 0 ]]; then
+            echo "pinning-lint: no unpinned action references found."
+            exit 0
+          fi
+
+          jq -r '
+            [.[] | select(.ident == "unpinned-uses")][]
+            | .locations[]
+            | "::warning file=\((.symbolic.key.Local.given_path // "<unknown>") | sub("^\\./"; "")),line=\(.concrete.location.start_point.row + 1),col=\(.concrete.location.start_point.column + 1),endLine=\(.concrete.location.end_point.row + 1),endColumn=\(.concrete.location.end_point.column + 1),title=Unpinned action ref::Action reference \(.concrete.feature) is not pinned to a commit SHA. See https://docs.zizmor.sh/audits/#unpinned-uses"
+          ' "$OUTPUT"
+
+          {
+            if [[ "$MODE" == "blocking" ]]; then
+              echo "### pinning-lint: $FINDINGS_COUNT unpinned action reference(s) (blocking)"
+              echo ""
+              echo "This check is failing because one or more \`uses:\` references are not pinned to a full-length commit SHA."
+            else
+              echo "### pinning-lint: $FINDINGS_COUNT unpinned action reference(s) (advisory)"
+              echo ""
+              echo "Advisory mode — not failing the job, but these \`uses:\` references should be pinned to a full-length commit SHA."
+            fi
+            echo ""
+            echo "| File | Line | Action reference |"
+            echo "| --- | --- | --- |"
+            jq -r '
+              [.[] | select(.ident == "unpinned-uses")][]
+              | .locations[]
+              | "| \((.symbolic.key.Local.given_path // "<unknown>") | sub("^\\./"; "")) | \(.concrete.location.start_point.row + 1) | `\(.concrete.feature)` |"
+            ' "$OUTPUT"
+            echo ""
+            echo "**How to fix:** replace each tag/branch ref with the full commit SHA, keeping the tag as a comment."
+            echo ""
+            echo '```yaml'
+            echo "# before"
+            echo "uses: actions/checkout@v4"
+            echo "# after"
+            echo "uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1"
+            echo '```'
+            echo ""
+            echo "See [zizmor unpinned-uses docs](https://docs.zizmor.sh/audits/#unpinned-uses) and [PLATFORM-764](https://rayatheapp.atlassian.net/browse/PLATFORM-764)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$MODE" == "blocking" ]]; then
+            echo "::error::pinning-lint: $FINDINGS_COUNT unpinned action reference(s) found (mode=blocking). See annotations and the job summary."
+            exit 1
+          fi
+
+          echo "::warning::pinning-lint: $FINDINGS_COUNT unpinned action reference(s) found (mode=advisory). See annotations and the job summary."
+          exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   publishGitRelease:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '^1.20'
           check-latest: true
@@ -46,7 +46,7 @@ jobs:
           ./scripts/xcompile.sh
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: build/*
           draft: true

--- a/.github/workflows/snap-release.yml
+++ b/.github/workflows/snap-release.yml
@@ -12,10 +12,10 @@ jobs:
       environment: snap
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
-        - uses: snapcore/action-build@v1
+        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
           id: build
-        - uses: snapcore/action-publish@v1
+        - uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
           env:
             SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
           with:

--- a/.github/workflows/test-yq.yml
+++ b/.github/workflows/test-yq.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Get test
         id: get_value
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@e95bb7e472727cada92b9ffbeb992653a0aa4184 # master
         with:
           cmd: yq '.test' examples/multiline-text.yaml
       - name: Multiline test
         run: echo "### It was [${{ steps.get_value.outputs.result }}]" >> $GITHUB_STEP_SUMMARY
       - name: Write inplace test
         id: lookupSdkVersion
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@e95bb7e472727cada92b9ffbeb992653a0aa4184 # master
         with:
           cmd: yq -i '.b.c = 5' examples/sample.yaml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "RayaTheApp/*": any
+        "rayatheapp/*": any
+        "*": hash-pin


### PR DESCRIPTION
## Summary of Changes
- Pinned all third-party GitHub Actions `uses:` across workflows and composite actions to immutable commit SHAs, preserving the original version as a `# vX` trailing comment.
- Fixed `rayatheapp/*` action owner casing to `RayaTheApp/*` where present.
- Added `.github/workflows/pinning-lint.yml` (blocking) using `RayaTheApp/actions/.github/actions/pinning-lint@master`.
- Added `.github/dependabot.yml` for grouped weekly GitHub Actions updates (assignee `dmcnaught`), where one did not already exist.
- Added `zizmor.yml` unpinned-uses policy: `RayaTheApp/*` allowed, everything else `hash-pin`.

Mirrors RayaTheApp/places-raya-backend#1290.

Refs PLATFORM-664